### PR TITLE
Add basic chatbox feature

### DIFF
--- a/app/Http/Controllers/Api/ConversationController.php
+++ b/app/Http/Controllers/Api/ConversationController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Conversation;
+use Illuminate\Http\Request;
+
+class ConversationController extends Controller
+{
+    public function index(Request $request)
+    {
+        $conversations = Conversation::where('user_id', $request->user()->id)
+            ->get(['id', 'name', 'phone_number']);
+
+        return response()->json($conversations);
+    }
+
+    public function show(Request $request, Conversation $conversation)
+    {
+        abort_unless($conversation->user_id === $request->user()->id, 403);
+
+        $conversation->load('messages');
+
+        return response()->json($conversation);
+    }
+}

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Conversation;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ChatController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $conversations = Conversation::where('user_id', $request->user()->id)
+            ->get(['id', 'name', 'phone_number']);
+
+        return Inertia::render('chat/index', [
+            'conversations' => $conversations,
+        ]);
+    }
+}

--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Conversation extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'phone_number',
+        'name',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function messages(): HasMany
+    {
+        return $this->hasMany(Message::class);
+    }
+}

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Message extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'conversation_id',
+        'content',
+        'is_outgoing',
+    ];
+
+    public function conversation(): BelongsTo
+    {
+        return $this->belongsTo(Conversation::class);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/database/factories/ConversationFactory.php
+++ b/database/factories/ConversationFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Conversation;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Conversation>
+ */
+class ConversationFactory extends Factory
+{
+    protected $model = Conversation::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'phone_number' => fake()->phoneNumber(),
+            'name' => fake()->name(),
+        ];
+    }
+}

--- a/database/factories/MessageFactory.php
+++ b/database/factories/MessageFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Conversation;
+use App\Models\Message;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Message>
+ */
+class MessageFactory extends Factory
+{
+    protected $model = Message::class;
+
+    public function definition(): array
+    {
+        return [
+            'conversation_id' => Conversation::factory(),
+            'content' => fake()->sentence(),
+            'is_outgoing' => fake()->boolean(),
+        ];
+    }
+}

--- a/database/migrations/0001_01_01_000003_create_conversations_table.php
+++ b/database/migrations/0001_01_01_000003_create_conversations_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('conversations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('phone_number');
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('conversations');
+    }
+};

--- a/database/migrations/0001_01_01_000004_create_messages_table.php
+++ b/database/migrations/0001_01_01_000004_create_messages_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('conversation_id')->constrained()->cascadeOnDelete();
+            $table->text('content');
+            $table->boolean('is_outgoing')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('messages');
+    }
+};

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
         "tailwindcss": "^4.0.0",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.7.2",
-        "vite": "^6.0"
+        "vite": "^6.0",
+        "axios": "^1.8.1"
     },
     "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.9.5",

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -4,7 +4,7 @@ import { NavUser } from '@/components/nav-user';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/react';
-import { BookOpen, Folder, LayoutGrid } from 'lucide-react';
+import { BookOpen, Folder, LayoutGrid, MessageCircle } from 'lucide-react';
 import AppLogo from './app-logo';
 
 const mainNavItems: NavItem[] = [
@@ -12,6 +12,11 @@ const mainNavItems: NavItem[] = [
         title: 'Dashboard',
         href: '/dashboard',
         icon: LayoutGrid,
+    },
+    {
+        title: 'Chat',
+        href: '/chat',
+        icon: MessageCircle,
     },
 ];
 

--- a/resources/js/lib/api.ts
+++ b/resources/js/lib/api.ts
@@ -1,0 +1,9 @@
+import axios from 'axios';
+
+const api = axios.create({
+    headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+    },
+});
+
+export default api;

--- a/resources/js/pages/chat/index.tsx
+++ b/resources/js/pages/chat/index.tsx
@@ -1,0 +1,72 @@
+import api from '@/lib/api';
+import AppLayout from '@/layouts/app-layout';
+import { BreadcrumbItem } from '@/types';
+import { Head } from '@inertiajs/react';
+import { useState } from 'react';
+
+interface Conversation {
+    id: number;
+    name?: string | null;
+    phone_number: string;
+}
+
+interface Message {
+    id: number;
+    content: string;
+    is_outgoing: boolean;
+}
+
+interface Props {
+    conversations: Conversation[];
+}
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Chat', href: '/chat' },
+];
+
+export default function ChatPage({ conversations: initialConversations }: Props) {
+    const [conversations] = useState(initialConversations);
+    const [selected, setSelected] = useState<Conversation | null>(null);
+    const [messages, setMessages] = useState<Message[]>([]);
+
+    const loadMessages = (conversation: Conversation) => {
+        setSelected(conversation);
+        api.get(`/api/conversations/${conversation.id}`).then((r) => {
+            setMessages(r.data.messages || []);
+        });
+    };
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Chat" />
+            <div className="flex h-full">
+                <div className="w-60 border-r">
+                    {conversations.map((conv) => (
+                        <button
+                            key={conv.id}
+                            onClick={() => loadMessages(conv)}
+                            className="block w-full p-2 text-left hover:bg-neutral-100 dark:hover:bg-neutral-800"
+                        >
+                            <div className="font-medium">
+                                {conv.name ?? conv.phone_number}
+                            </div>
+                            <div className="text-sm text-neutral-500">
+                                {conv.phone_number}
+                            </div>
+                        </button>
+                    ))}
+                </div>
+                <div className="flex-1 p-4 overflow-y-auto space-y-2">
+                    {selected &&
+                        messages.map((m) => (
+                            <div key={m.id} className={m.is_outgoing ? 'text-right' : ''}>
+                                <span className="inline-block rounded-xl px-3 py-2 bg-neutral-200 dark:bg-neutral-700">
+                                    {m.content}
+                                </span>
+                            </div>
+                        ))}
+                </div>
+            </div>
+        </AppLayout>
+    );
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\Http\Controllers\Api\ConversationController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('auth')->group(function () {
+    Route::get('conversations', [ConversationController::class, 'index']);
+    Route::get('conversations/{conversation}', [ConversationController::class, 'show']);
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('dashboard', function () {
         return Inertia::render('dashboard');
     })->name('dashboard');
+
+    Route::get('chat', [\App\Http\Controllers\ChatController::class, 'index'])->name('chat');
 });
 
 require __DIR__.'/settings.php';

--- a/tests/Feature/ChatTest.php
+++ b/tests/Feature/ChatTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\\Models\\Conversation;
+use App\\Models\\User;
+use Illuminate\\Foundation\\Testing\\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('guests are redirected to login when visiting chat', function () {
+    $this->get('/chat')->assertRedirect('/login');
+});
+
+test('authenticated users can view chat page', function () {
+    $user = User::factory()->create();
+    Conversation::factory()->for($user)->create();
+
+    $this->actingAs($user)->get('/chat')->assertOk();
+});
+
+test('api routes are auth protected', function () {
+    $user = User::factory()->create();
+    $conversation = Conversation::factory()->for($user)->create();
+
+    $this->getJson('/api/conversations')->assertUnauthorized();
+    $this->actingAs($user)->getJson('/api/conversations')->assertOk();
+    $this->actingAs($user)->getJson('/api/conversations/'.$conversation->id)->assertOk();
+});
+


### PR DESCRIPTION
## Summary
- scaffold conversations and messages tables
- create models, factories, and controllers for chat
- expose new web and API routes for chat
- add axios helper
- implement React chat page and link from sidebar
- enable API routing in application bootstrap
- add feature tests

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af8bfa474832d851301bb038a5c01