### PR TITLE
Implement conversation messaging with attachments

### DIFF
--- a/app/Http/Controllers/Api/ConversationController.php
+++ b/app/Http/Controllers/Api/ConversationController.php
@@ -24,4 +24,27 @@ class ConversationController extends Controller
 
         return response()->json($conversation);
     }
+
+    public function storeMessage(Request $request, Conversation $conversation)
+    {
+        abort_unless($conversation->user_id === $request->user()->id, 403);
+
+        $validated = $request->validate([
+            'content' => 'nullable|string',
+            'attachment' => 'nullable|file|mimes:pdf,jpg,jpeg,png,mp4,quicktime,mpeg',
+        ]);
+
+        $path = null;
+        if ($request->hasFile('attachment')) {
+            $path = $request->file('attachment')->store('attachments', 'public');
+        }
+
+        $message = $conversation->messages()->create([
+            'content' => $validated['content'] ?? '',
+            'attachment_path' => $path,
+            'is_outgoing' => true,
+        ]);
+
+        return response()->json($message, 201);
+    }
 }

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -13,8 +13,16 @@ class Message extends Model
     protected $fillable = [
         'conversation_id',
         'content',
+        'attachment_path',
         'is_outgoing',
     ];
+
+    protected $appends = ['attachment_url'];
+
+    public function getAttachmentUrlAttribute(): ?string
+    {
+        return $this->attachment_path ? asset('storage/'.$this->attachment_path) : null;
+    }
 
     public function conversation(): BelongsTo
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,11 +6,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, HasApiTokens;
 
     /**
      * The attributes that are mass assignable.

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -22,6 +22,8 @@ return Application::configure(basePath: dirname(__DIR__))
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,
         ]);
+
+        $middleware->statefulApi();
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "php": "^8.2",
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^12.0",
+        "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.10.1",
         "tightenco/ziggy": "^2.4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b7531f73c7a0f0d5c4e7e8690992afc1",
+    "content-hash": "5e04cf57350d8d8dd27eb272df084379",
     "packages": [
         {
             "name": "brick/math",
@@ -1395,6 +1395,70 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.3.5"
             },
             "time": "2025-02-11T13:34:40+00:00"
+        },
+        {
+            "name": "laravel/sanctum",
+            "version": "v4.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sanctum.git",
+                "reference": "a360a6a1fd2400ead4eb9b6a9c1bb272939194f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/a360a6a1fd2400ead4eb9b6a9c1bb272939194f5",
+                "reference": "a360a6a1fd2400ead4eb9b6a9c1bb272939194f5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^11.0|^12.0",
+                "illuminate/contracts": "^11.0|^12.0",
+                "illuminate/database": "^11.0|^12.0",
+                "illuminate/support": "^11.0|^12.0",
+                "php": "^8.2",
+                "symfony/console": "^7.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^9.0|^10.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sanctum\\SanctumServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sanctum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Sanctum provides a featherweight authentication system for SPAs and simple APIs.",
+            "keywords": [
+                "auth",
+                "laravel",
+                "sanctum"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sanctum/issues",
+                "source": "https://github.com/laravel/sanctum"
+            },
+            "time": "2025-04-23T13:03:38+00:00"
         },
         {
             "name": "laravel/serializable-closure",

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -1,0 +1,84 @@
+<?php
+
+use Laravel\Sanctum\Sanctum;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Stateful Domains
+    |--------------------------------------------------------------------------
+    |
+    | Requests from the following domains / hosts will receive stateful API
+    | authentication cookies. Typically, these should include your local
+    | and production domains which access your API via a frontend SPA.
+    |
+    */
+
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+        '%s%s',
+        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        Sanctum::currentApplicationUrlWithPort(),
+        // Sanctum::currentRequestHost(),
+    ))),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Guards
+    |--------------------------------------------------------------------------
+    |
+    | This array contains the authentication guards that will be checked when
+    | Sanctum is trying to authenticate a request. If none of these guards
+    | are able to authenticate the request, Sanctum will use the bearer
+    | token that's present on an incoming request for authentication.
+    |
+    */
+
+    'guard' => ['web'],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Expiration Minutes
+    |--------------------------------------------------------------------------
+    |
+    | This value controls the number of minutes until an issued token will be
+    | considered expired. This will override any values set in the token's
+    | "expires_at" attribute, but first-party sessions are not affected.
+    |
+    */
+
+    'expiration' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Token Prefix
+    |--------------------------------------------------------------------------
+    |
+    | Sanctum can prefix new tokens in order to take advantage of numerous
+    | security scanning initiatives maintained by open source platforms
+    | that notify developers if they commit tokens into repositories.
+    |
+    | See: https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning
+    |
+    */
+
+    'token_prefix' => env('SANCTUM_TOKEN_PREFIX', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Middleware
+    |--------------------------------------------------------------------------
+    |
+    | When authenticating your first-party SPA with Sanctum you may need to
+    | customize some of the middleware Sanctum uses while processing the
+    | request. You may change the middleware listed below as required.
+    |
+    */
+
+    'middleware' => [
+        'authenticate_session' => Laravel\Sanctum\Http\Middleware\AuthenticateSession::class,
+        'encrypt_cookies' => Illuminate\Cookie\Middleware\EncryptCookies::class,
+        'validate_csrf_token' => Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
+    ],
+
+];

--- a/database/factories/MessageFactory.php
+++ b/database/factories/MessageFactory.php
@@ -18,6 +18,7 @@ class MessageFactory extends Factory
         return [
             'conversation_id' => Conversation::factory(),
             'content' => fake()->sentence(),
+            'attachment_path' => null,
             'is_outgoing' => fake()->boolean(),
         ];
     }

--- a/database/migrations/0001_01_01_000004_create_messages_table.php
+++ b/database/migrations/0001_01_01_000004_create_messages_table.php
@@ -15,6 +15,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('conversation_id')->constrained()->cascadeOnDelete();
             $table->text('content');
+            $table->string('attachment_path')->nullable();
             $table->boolean('is_outgoing')->default(false);
             $table->timestamps();
         });

--- a/database/migrations/2025_06_25_044931_create_personal_access_tokens_table.php
+++ b/database/migrations/2025_06_25_044931_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/resources/js/lib/api.ts
+++ b/resources/js/lib/api.ts
@@ -1,4 +1,6 @@
 import axios from 'axios';
+axios.defaults.withCredentials = true;
+axios.defaults.withXSRFToken = true;
 
 const api = axios.create({
     headers: {

--- a/resources/js/pages/chat/index.tsx
+++ b/resources/js/pages/chat/index.tsx
@@ -14,6 +14,7 @@ interface Message {
     id: number;
     content: string;
     is_outgoing: boolean;
+    attachment_url?: string | null;
 }
 
 interface Props {
@@ -28,12 +29,30 @@ export default function ChatPage({ conversations: initialConversations }: Props)
     const [conversations] = useState(initialConversations);
     const [selected, setSelected] = useState<Conversation | null>(null);
     const [messages, setMessages] = useState<Message[]>([]);
+    const [content, setContent] = useState('');
+    const [attachment, setAttachment] = useState<File | null>(null);
 
     const loadMessages = (conversation: Conversation) => {
         setSelected(conversation);
         api.get(`/api/conversations/${conversation.id}`).then((r) => {
             setMessages(r.data.messages || []);
         });
+    };
+
+    const sendMessage = () => {
+        if (!selected) return;
+        const form = new FormData();
+        form.append('content', content);
+        if (attachment) {
+            form.append('attachment', attachment);
+        }
+        api
+            .post(`/api/conversations/${selected.id}/messages`, form)
+            .then((r) => {
+                setMessages((m) => [...m, r.data]);
+                setContent('');
+                setAttachment(null);
+            });
     };
 
     return (
@@ -56,15 +75,59 @@ export default function ChatPage({ conversations: initialConversations }: Props)
                         </button>
                     ))}
                 </div>
-                <div className="flex-1 p-4 overflow-y-auto space-y-2">
-                    {selected &&
-                        messages.map((m) => (
-                            <div key={m.id} className={m.is_outgoing ? 'text-right' : ''}>
-                                <span className="inline-block rounded-xl px-3 py-2 bg-neutral-200 dark:bg-neutral-700">
-                                    {m.content}
-                                </span>
+                <div className="flex-1 flex flex-col">
+                    <div className="flex-1 p-4 overflow-y-auto space-y-2">
+                        {selected &&
+                            messages.map((m) => (
+                                <div key={m.id} className={m.is_outgoing ? 'text-right' : ''}>
+                                    <div
+                                        className={
+                                            'inline-block max-w-xs rounded-xl px-3 py-2 ' +
+                                            (m.is_outgoing
+                                                ? 'bg-primary text-primary-foreground'
+                                                : 'bg-neutral-200 dark:bg-neutral-700')
+                                        }
+                                    >
+                                        {m.content && <p>{m.content}</p>}
+                                        {m.attachment_url && (
+                                            <a
+                                                href={m.attachment_url}
+                                                target="_blank"
+                                                rel="noreferrer"
+                                                className="underline block mt-1"
+                                            >
+                                                View attachment
+                                            </a>
+                                        )}
+                                    </div>
+                                </div>
+                            ))}
+                    </div>
+                    {selected && (
+                        <div className="border-t p-4 space-y-2">
+                            <textarea
+                                className="w-full border rounded-md p-2"
+                                rows={3}
+                                value={content}
+                                onChange={(e) => setContent(e.target.value)}
+                            />
+                            <input
+                                type="file"
+                                onChange={(e) =>
+                                    setAttachment(e.target.files ? e.target.files[0] : null)
+                                }
+                                accept=".pdf,.jpg,.jpeg,.png,video/*"
+                            />
+                            <div>
+                                <button
+                                    onClick={sendMessage}
+                                    className="mt-2 rounded-md bg-primary px-4 py-2 text-primary-foreground"
+                                >
+                                    Send
+                                </button>
                             </div>
-                        ))}
+                        </div>
+                    )}
                 </div>
             </div>
         </AppLayout>

--- a/resources/js/pages/chat/index.tsx
+++ b/resources/js/pages/chat/index.tsx
@@ -15,6 +15,7 @@ interface Message {
     content: string;
     is_outgoing: boolean;
     attachment_url?: string | null;
+    created_at?: string | null;
 }
 
 interface Props {
@@ -76,7 +77,7 @@ export default function ChatPage({ conversations: initialConversations }: Props)
                     ))}
                 </div>
                 <div className="flex-1 flex flex-col">
-                    <div className="flex-1 p-4 overflow-y-auto space-y-2">
+                    <div className="flex-1 p-4 overflow-y-auto space-y-4">
                         {selected &&
                             messages.map((m) => (
                                 <div key={m.id} className={m.is_outgoing ? 'text-right' : ''}>
@@ -100,6 +101,11 @@ export default function ChatPage({ conversations: initialConversations }: Props)
                                             </a>
                                         )}
                                     </div>
+                                    {m.created_at && (
+                                        <div className="text-xs text-neutral-500 mt-1">
+                                            {new Date(m.created_at).toLocaleDateString()} {new Date(m.created_at).toLocaleTimeString()}
+                                        </div>
+                                    )}
                                 </div>
                             ))}
                     </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,4 +6,5 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth')->group(function () {
     Route::get('conversations', [ConversationController::class, 'index']);
     Route::get('conversations/{conversation}', [ConversationController::class, 'show']);
+    Route::post('conversations/{conversation}/messages', [ConversationController::class, 'storeMessage']);
 });

--- a/tests/Feature/ChatTest.php
+++ b/tests/Feature/ChatTest.php
@@ -26,3 +26,15 @@ test('api routes are auth protected', function () {
     $this->actingAs($user)->getJson('/api/conversations/'.$conversation->id)->assertOk();
 });
 
+test('authenticated users can send messages', function () {
+    $user = User::factory()->create();
+    $conversation = Conversation::factory()->for($user)->create();
+
+    $this->actingAs($user)
+        ->postJson('/api/conversations/'.$conversation->id.'/messages', [
+            'content' => 'Hello',
+        ])
+        ->assertCreated()
+        ->assertJsonPath('content', 'Hello');
+});
+


### PR DESCRIPTION
## Summary
- enable file attachments for messages
- add POST API endpoint to send a message
- show messages and attachments in chat UI
- allow sending messages from UI
- test new messaging endpoint

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run types` *(fails due to missing dependencies)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b7beac4f4832d82a8a12d6e928678