### PR TITLE
Add Twilio webhook endpoint

### DIFF
--- a/app/Http/Controllers/Webhooks/TwilioWebhookController.php
+++ b/app/Http/Controllers/Webhooks/TwilioWebhookController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Webhooks;
+
+use App\DTO\MessageData;
+use App\Http\Controllers\Controller;
+use App\Models\Conversation;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+class TwilioWebhookController extends Controller
+{
+    public function __invoke(Request $request)
+    {
+        $validated = $request->validate([
+            'From' => 'required|string',
+            'Body' => 'nullable|string',
+            'NumMedia' => 'nullable|integer',
+        ]);
+
+        $from = $validated['From'];
+        $body = $validated['Body'] ?? '';
+
+        $conversation = Conversation::firstOrCreate(
+            ['phone_number' => $from],
+            [
+                'user_id' => User::query()->value('id'),
+                'name' => null,
+            ]
+        );
+
+        $attachmentPath = null;
+        $numMedia = (int) ($validated['NumMedia'] ?? 0);
+        if ($numMedia > 0) {
+            $url = $request->input('MediaUrl0');
+            if ($url) {
+                $extension = pathinfo(parse_url($url, PHP_URL_PATH), PATHINFO_EXTENSION) ?: 'jpg';
+                try {
+                    $response = Http::get($url);
+                    if ($response->successful()) {
+                        $filename = 'attachments/' . uniqid() . '.' . $extension;
+                        Storage::disk('public')->put($filename, $response->body());
+                        $attachmentPath = $filename;
+                    }
+                } catch (\Throwable $th) {
+                    // Ignore download failures
+                }
+            }
+        }
+
+        $data = MessageData::create(
+            $conversation->id,
+            $body,
+            $attachmentPath,
+            false
+        );
+
+        $message = $conversation->messages()->create($data->toArray());
+
+        return response()->json($message, 201);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\ConversationController;
+use App\Http\Controllers\Webhooks\TwilioWebhookController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth')->group(function () {
@@ -9,3 +10,5 @@ Route::middleware('auth')->group(function () {
     Route::get('conversations/{conversation}', [ConversationController::class, 'show']);
     Route::post('conversations/{conversation}/messages', [ConversationController::class, 'storeMessage']);
 });
+
+Route::post('webhooks/twilio', TwilioWebhookController::class);

--- a/tests/Feature/TwilioWebhookTest.php
+++ b/tests/Feature/TwilioWebhookTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Models\Conversation;
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+use function Pest\Laravel\post;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('stores an incoming message', function () {
+    $user = User::factory()->create();
+    $conversation = Conversation::factory()->for($user)->create([
+        'phone_number' => '+1234567890',
+    ]);
+
+    post('/api/webhooks/twilio', [
+        'From' => '+1234567890',
+        'Body' => 'Hello',
+        'NumMedia' => 0,
+    ])->assertCreated();
+
+    expect($conversation->messages()->count())->toBe(1)
+        ->and($conversation->messages()->first()->is_outgoing)->toBeFalse();
+});
+
+it('stores media from twilio', function () {
+    Storage::fake('public');
+    Http::fake([
+        'https://example.com/image.jpg' => Http::response('image', 200),
+    ]);
+
+    $user = User::factory()->create();
+    $conversation = Conversation::factory()->for($user)->create([
+        'phone_number' => '+1987654321',
+    ]);
+
+    post('/api/webhooks/twilio', [
+        'From' => '+1987654321',
+        'Body' => '',
+        'NumMedia' => 1,
+        'MediaUrl0' => 'https://example.com/image.jpg',
+    ])->assertCreated();
+
+    $message = $conversation->messages()->first();
+    expect($message->attachment_path)->not()->toBeNull();
+    Storage::disk('public')->assertExists($message->attachment_path);
+});


### PR DESCRIPTION
## Summary
- handle Twilio incoming messages in a new webhook controller
- register a public API route for Twilio webhooks
- add tests covering webhook message storage and media handling

## Testing
- `composer test` *(fails: composer not found)*
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec7ad0318832da39c2e96728f51be