### PR TITLE
Fix custom event listener

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -4,14 +4,7 @@ import { createInertiaApp } from '@inertiajs/react';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { createRoot } from 'react-dom/client';
 import { initializeTheme } from './hooks/use-appearance';
-import { configureEcho } from '@laravel/echo-react';
-
-configureEcho({
-    broadcaster: 'pusher',
-    key: import.meta.env.VITE_PUSHER_APP_KEY || '',
-    cluster: import.meta.env.VITE_PUSHER_APP_CLUSTER || 'us1',
-    forceTLS: import.meta.env.VITE_PUSHER_SCHEME === 'https',
-});
+import './lib/echo';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 

--- a/resources/js/lib/echo.ts
+++ b/resources/js/lib/echo.ts
@@ -1,0 +1,14 @@
+import Echo from 'laravel-echo';
+import Pusher from 'pusher-js';
+
+window.Pusher = Pusher;
+
+const echo = new Echo({
+    broadcaster: 'pusher',
+    key: import.meta.env.VITE_PUSHER_APP_KEY || '',
+    cluster: import.meta.env.VITE_PUSHER_APP_CLUSTER || 'us1',
+    forceTLS: import.meta.env.VITE_PUSHER_SCHEME === 'https',
+});
+
+export default echo;
+

--- a/resources/js/pages/chat/index.tsx
+++ b/resources/js/pages/chat/index.tsx
@@ -45,11 +45,18 @@ export default function ChatPage({ conversations: initialConversations }: Props)
         const channelName = `conversations.${selected.id}`;
         const channel = echo.private(channelName);
 
-        const handler = (e: unknown) => {
-            console.log(e);
+        const handler = (e: { conversation: Conversation, message: Message }) => {
+            if (e.conversation.id !== selected.id) return;
+
+            setMessages((prevMessages) => [...prevMessages, e.message]);
+
+            const messageContainer = document.querySelector('.message-container');
+            if (messageContainer) {
+                messageContainer.scrollTop = messageContainer.scrollHeight;
+            }
         };
 
-        channel.listen('MessageReceived', handler);
+        channel.listen('.MessageReceived', handler);
 
         return () => {
             channel.stopListening('MessageReceived');

--- a/resources/js/types/echo.d.ts
+++ b/resources/js/types/echo.d.ts
@@ -1,0 +1,11 @@
+import Echo from 'laravel-echo';
+import Pusher from 'pusher-js';
+
+declare global {
+    interface Window {
+        Echo: Echo;
+        Pusher: typeof Pusher;
+    }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- listen to `MessageReceived` events using the standard Echo client
- configure Echo outside of React via a helper

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862bf1d6e04832da40d1ce72189205d